### PR TITLE
feat(rules): dirname supports Windows backslash

### DIFF
--- a/lib/rules/dirnames.js
+++ b/lib/rules/dirnames.js
@@ -3,6 +3,7 @@
  * @author Deland Li
  */
 'use strict';
+var path = require('path');
 var utils = require('../utils/index.js');
 
 var DEFAULT_PATTERN = '^[a-zA-Z0-9_-]+$';
@@ -47,7 +48,7 @@ module.exports = {
                     return;
                 }
 
-                var dirFragments = dirname.split('/');
+                var dirFragments = dirname.split(path.sep);
 
                 var isDirnameValid = true;
                 for (var i = 0; i < dirFragments.length; i++) {

--- a/tests/lib/rules/dirnames.js
+++ b/tests/lib/rules/dirnames.js
@@ -3,6 +3,7 @@
  * @author
  */
 'use strict';
+var path = require('path');
 var rule = require('../../../lib/rules/dirnames');
 var RuleTester = require('eslint').RuleTester;
 
@@ -34,7 +35,9 @@ ruleTester.run('dirnames', rule, {
             filename: 'User/src/$components/Button.jsx',
             errors: [
                 {
-                    message: 'Dirnames in \'User/src/$components\' should match pattern: \'^[a-zA-Z0-9_-]+$\'',
+                    message: 'Dirnames in \''
+                        + path.join('User', 'src', '$components')
+                        + '\' should match pattern: \'^[a-zA-Z0-9_-]+$\'',
                 },
             ],
         },


### PR DESCRIPTION
Node.js uses the backslash (`"\\"`) on Windows, which makes this plugin throw errors in all sub directories (such as `"src\\components"`). This PR fixes the issue.